### PR TITLE
ignore node_modules/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+node_modules/
 .nyc_output
 coverage


### PR DESCRIPTION
To run the application we must install packages, and when we do that git will try to track each file on the folder.
and that is not recommended when developing applications with Node.